### PR TITLE
Use docker to build contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,13 @@
 BIN := contracts/ckb-dynamic-loading-rsa/target/riscv64imac-unknown-none-elf/debug/ckb-dynamic-loading-rsa
 
-test: contract fix
+test: build/debug/ckb-dynamic-loading-rsa
 	cargo test
 
 install-tools:
 	cargo install --git https://github.com/xxuejie/ckb-binary-patcher.git
-	rustup toolchain install nightly-2020-09-28
 
-	
 contract:
-	cd contracts/ckb-dynamic-loading-rsa && cargo build
+	docker run --rm -v `pwd`:/code jjy0/ckb-capsule-recipe-rust:2020-9-28 bash -c "cd /code/contracts/ckb-dynamic-loading-rsa && cargo build"
 
 fix:
 	ckb-binary-patcher -i $(BIN) -o build/debug/ckb-dynamic-loading-rsa


### PR DESCRIPTION
Otherwise it will report:
```
$ make contract
cd contracts/ckb-dynamic-loading-rsa && cargo build
   Compiling cc v1.0.58
   Compiling cfg-if v0.1.10
   Compiling buddy-alloc v0.3.0
   Compiling molecule v0.6.0
   Compiling ckb-allocator v0.1.1
   Compiling ckb-standalone-types v0.0.1-pre.1
   Compiling blake2b-rs v0.1.5
   Compiling ckb-std v0.6.2
The following warnings were emitted during compilation:

warning: riscv64-unknown-elf-gcc: error trying to exec 'cc1': execvp: No such file or directory

error: failed to run custom build command for `ckb-std v0.6.2`

Caused by:
  process didn't exit successfully: `/xxx/ckb-dynamic-loading-rsa/contracts/ckb-dynamic-loading-rsa/target/debug/build/ckb-std-405056704b180b4d/build-script-build` (exit code: 1)
  --- stdout
  TARGET = Some("riscv64imac-unknown-none-elf")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-unknown-linux-gnu")
  CC_riscv64imac-unknown-none-elf = None
  CC_riscv64imac_unknown_none_elf = None
  TARGET_CC = None
  CC = None
  CROSS_COMPILE = None
  CFLAGS_riscv64imac-unknown-none-elf = None
  CFLAGS_riscv64imac_unknown_none_elf = None
  TARGET_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("a,c,m")
  running: "riscv64-unknown-elf-gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-march=rv64imac" "-mabi=lp64" "-mcmodel=medany" "-Wall" "-Wextra" "-o" "/xxx/ckb-dynamic-loading-rsa/contracts/ckb-dynamic-loading-rsa/ta
rget/riscv64imac-unknown-none-elf/debug/build/ckb-std-652e551f205c2f8d/out/src/asm/syscall.o" "-c" "src/asm/syscall.S"
  cargo:warning=riscv64-unknown-elf-gcc: error trying to exec 'cc1': execvp: No such file or directory
  exit code: 1

  --- stderr


  error occurred: Command "riscv64-unknown-elf-gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-march=rv64imac" "-mabi=lp64" "-mcmodel=medany" "-Wall" "-Wextra" "-o" "/xxx/ckb-dynamic-loading-rsa/contracts/ckb-dynamic
-loading-rsa/target/riscv64imac-unknown-none-elf/debug/build/ckb-std-652e551f205c2f8d/out/src/asm/syscall.o" "-c" "src/asm/syscall.S" with args "riscv64-unknown-elf-gcc" did not execute successfully (status code exit code: 1).


warning: build failed, waiting for other jobs to finish...
error: build failed
make: *** [Makefile:11: contract] Error 101

```